### PR TITLE
[BPK-4006]: Added new components to linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 _Nothing yet..._
 
+- Added new `use-component` rules for React Native components
+  - `BpkFlatList`, `BpkPicker`, `BpkSectionList`, `BpkSwitch`, `BpkTextInput`
+
+
 ## 1.0.1 - 2020-05-26 - Moved Snyk dep
   - Moved Snyk dependency to devDeps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-backpack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rules/use-components.js
+++ b/src/rules/use-components.js
@@ -19,25 +19,36 @@ const merge = require('lodash/merge');
 
 const { addImport, getImportDefinition } = require('../auto-import');
 
+const BPK_PATH = 'backpack-react-native/';
+
 const BPK_SUBSTITUTES = {
   ActivityIndicator: 'BpkSpinner',
   Alert: 'BpkAlert',
   Button: 'BpkButton',
+  FlatList: 'BpkFlatList',
   Image: 'BpkImage',
+  Picker: 'BpkPicker',
+  SectionList: 'BpkSectionList',
+  Switch: 'BpkSwitch',
   Text: 'BpkText',
+  TextInput: 'BpkTextInput',
   TouchableHighlight: 'BpkTouchableOverlay',
   TouchableNativeFeedback: 'BpkTouchableNativeFeedback',
 };
 
 const PACKAGES = {
-  BpkSpinner: 'react-native-bpk-component-spinner',
-  BpkAlert: 'react-native-bpk-component-alert',
-  BpkButton: 'react-native-bpk-component-button',
-  BpkImage: 'react-native-bpk-component-image',
-  BpkText: 'react-native-bpk-component-text',
-  BpkTouchableOverlay: 'react-native-bpk-component-touchable-overlay',
-  BpkTouchableNativeFeedback:
-    'react-native-bpk-component-touchable-native-feedback',
+  BpkSpinner: 'bpk-component-spinner',
+  BpkAlert: 'bpk-component-alert',
+  BpkButton: 'bpk-component-button',
+  BpkFlatList: 'bpk-component-flat-list',
+  BpkImage: 'bpk-component-image',
+  BpkPicker: 'bpk-component-picker',
+  BpkSectionList: 'bpk-component-section-list',
+  BpkSwitch: 'bpk-component-switch',
+  BpkText: 'bpk-component-text',
+  BpkTextInput: 'bpk-component-text-input',
+  BpkTouchableOverlay: 'bpk-component-touchable-overlay',
+  BpkTouchableNativeFeedback: 'bpk-component-touchable-native-feedback',
 };
 
 const BASE_CONFIG = {
@@ -49,7 +60,7 @@ const ruleMessage = bkpComponent =>
 
 const fixAndMaybeImport = (fixer, options, node, identifier, fixes) => {
   const config = merge({}, BASE_CONFIG, options);
-  const packageName = PACKAGES[identifier];
+  const packageName = BPK_PATH + PACKAGES[identifier];
 
   if (!config.autoImport) {
     return fixes;

--- a/src/rules/use-components.test.js
+++ b/src/rules/use-components.test.js
@@ -20,6 +20,8 @@ const { RuleTester } = require('eslint');
 
 const useComponents = require('./use-components');
 
+const BPK_PATH = 'backpack-react-native/';
+
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2015,
@@ -29,22 +31,29 @@ const ruleTester = new RuleTester({
 });
 
 [
-  ['ActivityIndicator', 'BpkSpinner', 'react-native-bpk-component-spinner'],
-  ['Alert', 'BpkAlert', 'react-native-bpk-component-alert'],
-  ['Button', 'BpkButton', 'react-native-bpk-component-button'],
-  ['Image', 'BpkImage', 'react-native-bpk-component-image'],
-  ['Text', 'BpkText', 'react-native-bpk-component-text'],
+  ['ActivityIndicator', 'BpkSpinner', 'bpk-component-spinner'],
+  ['Alert', 'BpkAlert', 'bpk-component-alert'],
+  ['Button', 'BpkButton', 'bpk-component-button'],
+  ['FlatList', 'BpkFlatList', 'bpk-component-flat-list'],
+  ['Image', 'BpkImage', 'bpk-component-image'],
+  ['Picker', 'BpkPicker', 'bpk-component-picker'],
+  ['SectionList', 'BpkSectionList', 'bpk-component-section-list'],
+  ['Switch', 'BpkSwitch', 'bpk-component-switch'],
+  ['Text', 'BpkText', 'bpk-component-text'],
+  ['TextInput', 'BpkTextInput', 'bpk-component-text-input'],
   [
     'TouchableHighlight',
     'BpkTouchableOverlay',
-    'react-native-bpk-component-touchable-overlay',
+    'bpk-component-touchable-overlay',
   ],
   [
     'TouchableNativeFeedback',
     'BpkTouchableNativeFeedback',
-    'react-native-bpk-component-touchable-native-feedback',
+    'bpk-component-touchable-native-feedback',
   ],
 ].forEach(([Component, Substitute, pkg]) => {
+  const pkgPath = BPK_PATH + pkg;
+
   ruleTester.run(`use-components - ${Component}`, useComponents, {
     valid: [
       `<${Substitute}>I'm allowed</${Substitute}>`,
@@ -56,7 +65,7 @@ const ruleTester = new RuleTester({
       {
         code: `React.createElement(${Component}, null, "I'm not allowed")`,
         output: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 React.createElement(${Substitute}, null, "I'm not allowed")`,
         errors: [
           {
@@ -67,7 +76,7 @@ React.createElement(${Substitute}, null, "I'm not allowed")`,
       {
         code: `create(${Component}, null, "I'm not allowed")`,
         output: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 create(${Substitute}, null, "I'm not allowed")`,
         errors: [
           {
@@ -78,7 +87,7 @@ create(${Substitute}, null, "I'm not allowed")`,
       {
         code: `<${Component}>I'm not allowed</${Component}>`,
         output: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 <${Substitute}>I'm not allowed</${Substitute}>`,
         errors: [
           {
@@ -89,7 +98,7 @@ import ${Substitute} from '${pkg}';
       {
         code: `<${Component} children="I'm not allowed" />`,
         output: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 <${Substitute} children="I'm not allowed" />`,
         errors: [
           {
@@ -109,10 +118,10 @@ import ${Substitute} from '${pkg}';
       },
       {
         code: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 <${Component} children="I'm not allowed" />`,
         output: `
-import ${Substitute} from '${pkg}';
+import ${Substitute} from '${pkgPath}';
 <${Substitute} children="I'm not allowed" />`,
         errors: [
           {


### PR DESCRIPTION
Added new `use-component` rules for React Native components
  - `BpkFlatList`, `BpkPicker`, `BpkSectionList`, `BpkSwitch`, `BpkTextInput` 