### PR TITLE
Updating to use nvm lts/hydrogen

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "prettier": "^1.19.1"
       },
       "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
+        "node": ">=18.16.0",
+        "npm": ">=9.5.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "pretest": "npx ensure-node-env",
+    "pretest": "npx ensure-node-env@2.0.0",
     "test": "mocha --recursive \"src/**/*.test.js\"",
     "lint:js:fix": "eslint . --ext js,jsx --fix",
     "prettier": "prettier --config .prettierrc --write \"**/*.{js,jsx}\""


### PR DESCRIPTION
Updates plugin to use lts/hydrogen (v18) by default.

- Updating the `nvmrc` file to point to `lts/hydrogen`
- Updating the `ensure-node-env` command to use the version 2 which supports Node 18