### PR TITLE
Remove dependencies label from label-check

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: major,minor,patch,dependencies,skip-changelog
+          one_of: major,minor,patch,skip-changelog
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependabot frequently submits two labels (dependencies and major/minor etc) and we expect only one, meaning the label-check breaks the builds. 

We don't care for dependencies as it doesn't influence release versioning.