### PR TITLE
[ARGG-1057]: Setup dependabot to ignore patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   versioning-strategy: increase
+  ignore:
+    - dependency-name: '*'
+      update-types: ['version-update:semver-patch']


### PR DESCRIPTION
Patch versions generate a lot of toil without providing a high amount of value.

We can opt out of receiving automated PRs for these, while still receiving PRs for minor and major versions.

https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore
