### PR TITLE
upgrade actions/cache, actions/checkouts, actions/setup-node

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -22,7 +22,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.2.3
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,15 +19,15 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,15 +19,15 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,15 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         id: npm-cache
         with:
           path: |
@@ -48,17 +48,17 @@ jobs:
     needs: [Create-NPM-Cache, Run-Tests]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.2.3
         id: npm-cache
         with:
           path: |


### PR DESCRIPTION
Because we got an error on github actions https://github.com/Skyscanner/eslint-plugin-backpack/actions/runs/14039826081/job/39306913839?pr=181
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/8c531974-323e-44ac-8840-7e166c0ae952" />

therefore, we need to upgrade github actions dependency
https://github.com/actions/cache/releases/tag/v4.2.3
https://github.com/actions/setup-node/tree/v4/
https://github.com/actions/checkout/tree/v4/
