### PR TITLE
[CLOV-1254] Use NPM trusted publishing (OIDC) and bump Node to 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,11 @@ jobs:
           ref: main
           persist-credentials: false
 
+      # Node 24 ships npm >= 11.5.1, which is required for trusted publishing
+      # (OIDC). Only the release job needs it; tests still use the .nvmrc Node.
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version-file: '.nvmrc'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache
@@ -71,11 +73,6 @@ jobs:
           path: |
             node_modules/
           key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
-
-      # Trusted publishing (OIDC) requires npm >= 11.5.1; the version bundled
-      # with the .nvmrc Node release is older, so pin an npm that supports it.
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@11.5.1
 
       - name: Publish NPM package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [Create-NPM-Cache, Run-Tests]
     permissions:
       id-token: write # Enables OIDC trusted publishing to NPM
+      contents: read # Required for actions/checkout after narrowing permissions
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # Avoid cache-poisoning risk in the release workflow
 
       - name: Upload to Cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -66,6 +67,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # Avoid cache-poisoning risk in the release workflow
 
       - name: Restore Cache
         uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Publishing
     needs: [Create-NPM-Cache, Run-Tests]
+    permissions:
+      id-token: write # Enables OIDC trusted publishing to NPM
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -70,10 +72,14 @@ jobs:
             node_modules/
           key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; the version bundled
+      # with the .nvmrc Node release is older, so pin an npm that supports it.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.5.1
+
       - name: Publish NPM package
         run: |
           npm version $RELEASE_VERSION --no-git-tag-version
           npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -78,6 +78,10 @@ jobs:
       - name: Publish NPM package
         run: |
           npm version $RELEASE_VERSION --no-git-tag-version
-          npm publish
+          npm publish --provenance
         env:
+          # Retained as a temporary fallback: npm prefers OIDC (trusted
+          # publishing) and only falls back to this token if OIDC is
+          # unavailable. Remove once the first OIDC release is verified.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,11 @@ jobs:
           ref: main
           persist-credentials: false
 
-      # Node 24 ships npm >= 11.5.1, which is required for trusted publishing
-      # (OIDC). Only the release job needs it; tests still use the .nvmrc Node.
+      # .nvmrc pins Node 24 (lts/krypton), which ships npm >= 11.5.1 as
+      # required for trusted publishing (OIDC).
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/krypton


### PR DESCRIPTION
## Problem

The release workflow authenticates to NPM with a long-lived `NPM_TOKEN` secret. Long-lived tokens can leak and require manual rotation — this is the risk flagged by the GitHub code-scanning alert ([CLOV-1254](https://skyscanner.atlassian.net/browse/CLOV-1254), [alert](https://github.com/Skyscanner/eslint-plugin-backpack/security/code-scanning/1)): _"prefer trusted publishing for authentication"_.

## Solution

Switch to NPM **Trusted Publishing (OIDC)** so GitHub Actions mints a short-lived, per-run credential at publish time instead of relying on a stored token. Changes:

- Add `permissions: id-token: write` to the `Release` job to enable the OIDC token exchange.
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.
- **Bump `.nvmrc` to `lts/krypton` (Node 24)** for the whole repo. Trusted publishing requires npm ≥ 11.5.1, and Node 24 is the earliest release that bundles it (Node 18/20/22 top out at npm 10.x). The release job reads `.nvmrc` as before, so dev, test and release all run the same Node version — no dev/publish split.

## Node 24 upgrade — no breaking changes for this repo

Verified locally under **Node 24.18.0 / npm 11.16.0**:

| Check | Result |
|-------|--------|
| `npm ci` | ✅ clean install |
| `npm test` (mocha) | ✅ 200 passing |
| `npm test` with `--throw-deprecation --pending-deprecation` | ✅ 200 passing, zero deprecation warnings — no code path touches any API deprecated/removed in Node 24 |
| `npm run lint` (eslint 9) | ✅ exit 0 |
| `npm publish --dry-run` (npm 11) | ✅ packs correctly, contents unchanged |

Reviewed the Node 24 and npm 11 changelogs against this package:
- Pure-JS package with **no native dependencies**, so the V8 ABI bump (NODE_MODULE_VERSION 137) is irrelevant.
- npm 11 breaking changes don't apply: we publish a normal (non-pre-release) version, don't use `--ignore-scripts`, `npm hook`, or the removed audit fallback.
- Node 24 API deprecations/removals (`url.parse`, `SlowBuffer`, `tls.createSecurePair`, etc.) are not hit by our code or tests (confirmed via `--throw-deprecation`).
- **`engines.node` is left unchanged (`>=16.13.0`)**, so consumers of the published package are unaffected — the Node version change only applies to CI.

## ⚠️ Prerequisite before merging / next release

A **Trusted Publisher must be configured on npmjs.com** for `eslint-plugin-backpack` (requires npm org admin):
`Settings` → Trusted Publisher → GitHub Actions → org `Skyscanner`, repo `eslint-plugin-backpack`, workflow `release.yml`, environment `Publishing`.

If the token is removed here before the trusted publisher is registered on npm, the next release will fail OIDC authentication. Once a release succeeds via OIDC, the old `NPM_TOKEN` secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLOV-1254]: https://skyscanner.atlassian.net/browse/CLOV-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ