### PR TITLE
[CLOV-1254] Drop --provenance from npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Publish NPM package
         run: |
           npm version $RELEASE_VERSION --no-git-tag-version
-          npm publish --provenance
+          npm publish
         env:
           # Retained as a temporary fallback: npm prefers OIDC (trusted
           # publishing) and only falls back to this token if OIDC is


### PR DESCRIPTION
## Problem

The first OIDC-based release (v7.4.1, [run](https://github.com/Skyscanner/eslint-plugin-backpack/actions/runs/29901699658/job/88863775282)) failed at the publish step:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/eslint-plugin-backpack -
  Error verifying sigstore provenance bundle:
  Unsupported OIDC token issuer: https://token.actions.githubusercontent.com/skyscanner.
  Only https://token.actions.githubusercontent.com, https://gitlab.com are currently supported.
```

Skyscanner's org uses a **customized GitHub Actions OIDC issuer** (the issuer URL carries the enterprise slug, `.../skyscanner`). npm's sigstore provenance verification only accepts the standard issuer `https://token.actions.githubusercontent.com`, so the provenance bundle is rejected.

Note this failure happens **only at the provenance verification stage** — the OIDC token was issued and the provenance statement was signed. This is an org-level OIDC config incompatibility, not a workflow error.

## Change

Drop `--provenance` from `npm publish`. This bypasses the provenance verification that npm rejects, so the release can complete. Trusted publishing authentication is unaffected, and `NODE_AUTH_TOKEN` remains in place as a fallback, so the publish succeeds either way.

## Trade-off / follow-up

Removing `--provenance` means published versions no longer carry a sigstore provenance attestation. Restoring it would require the **org-level custom OIDC issuer** to be made compatible with npm (or exempted for the npm publish path) — that's a platform-team change, out of scope for this repo. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)